### PR TITLE
docs fixes

### DIFF
--- a/docs/guide/src/guide/architecture.gdoc
+++ b/docs/guide/src/guide/architecture.gdoc
@@ -7,7 +7,7 @@ understand things on a general level.
 Others prefer to start with concrete demos and use cases, which is just as legitimate.
 In this case, you are welcome to skip the architecture section and directly jump to the [demos|guide:demos].
 
-The Dolphin architecture is made from two parts:
+The Dolphin architecture consists of two parts:
 
 # the structure
 # concepts and rules

--- a/docs/guide/src/guide/architecture/architecture_structure.gdoc
+++ b/docs/guide/src/guide/architecture/architecture_structure.gdoc
@@ -5,18 +5,18 @@ Dolphin consists of three parts:
 # the client module
 # the server module
 
-Both, client and server depend on the shared module.
+Both client and server modules depend on the shared module.
 
 There is an additional fourth module called "combined", which
 depends on all three modules above and allows combining them in one single
 Java virtual machine for automatic testing, debugging, profiling and demo purposes.
 
-All modules live in their own subproject with a separate source tree
+All modules live in their own subproject with separate source trees,
 and the Gradle build system is
 used to build them according to their dependency structure.
 
 Each project that uses Dolphin will most likely resemble this structure
-where the shared module may be empty (in case they is no shared knowledge
+where the shared module may be empty (in case there is no shared knowledge
 between client and server).
 
 The Dolphin team has produced a [JumpStartProject|https://github.com/canoo/DolphinJumpStart]
@@ -32,10 +32,10 @@ h4. The horizontal layering
 
 Orthogonally to the vertical structure of modules, there is a simple horizontal
 layering that spans across all modules. In consists of:
-- the common infrastructure for build automation, configurations, etc.
-- the communication layer that provides the basic implementation
-- the facade layer that provides the API
-- the demo layer that shows all Dolphin features in small examples
+- the common infrastructure for build automation, configurations, etc.;
+- the communication layer that provides the basic implementation;
+- the facade layer that provides the API;
+- the demo layer that shows all Dolphin features in small examples.
 
 The layering is visible through the respective package structure.
 

--- a/docs/guide/src/guide/architecture/concepts_attributes.gdoc
+++ b/docs/guide/src/guide/architecture/concepts_attributes.gdoc
@@ -11,7 +11,7 @@ Technically, this is done via the standard Java @PropertyChangeListener@ type.
 In other words, attributes are @Observable@.
 
 In addition to the value, attributes provide more information about the value, e.g.
-whether the value is _dirty_ (i.e. it differs from the _base value_).
+whether the value is _dirty_ (i.e., it differs from the _base value_).
 The dirty state is observable such that you can bind against it.
 As soon as at least one attribute of a presentation model is dirty, that presentation
 model is also considered dirty.
@@ -26,10 +26,10 @@ are automatically updated.
 
 Qualifiers are a prerequisite for [stable bindings|guide:concepts_binding].
 
-Since version 0.4 Dolphin attributes can be tagged in order to describe the meaning of
-the value. The @Tag@ enumeration provides all possible tags with @VALUE@ being the default.
+Dolphin attributes can be tagged in order to describe the meaning of
+the value. The @Tag@ enumeration provides all possible tags, with @VALUE@ being the default.
 Tags can be used to e.g. describe whether the person firstname is a @MANDATORY@ attribute,
 whether it is @ENABLED@, @VISIBLE@, and so on.
-Attributes with a tag are observable in the usual way.
+All attributes, even those with a non-default tag, are observable in the usual way.
 
 See also [Usage|Attribute] and [API doc|api:org.opendolphin.core.Attribute].

--- a/docs/guide/src/guide/architecture/concepts_binding.gdoc
+++ b/docs/guide/src/guide/architecture/concepts_binding.gdoc
@@ -1,11 +1,11 @@
 _Binding_ is just another word for an event listener listening to an event source.
 
-OpenDolphin supports binding between attributes and arbitrary other objects where
+OpenDolphin supports binding between attributes and other arbitrary objects where
 most of the time, these other objects are views - with the notable exception of
 the dolphin infrastructure itself, which automatically listens for value changes
 in order to notify the server.
 
-While OpenDolphin is independent on any specific UI toolkit and works out-of-the-box
+While OpenDolphin is independent of any specific UI toolkit and works out-of-the-box
 with every technology that understands PropertyChangeListeners (e.g. SWT and
 Eclipse RCP), it provides special binding facilities for
 - JavaFx and
@@ -22,11 +22,11 @@ for use cases where a selection changes the to-be-displayed information, commonl
 known as master-detail views.
 
 Master-detail views come in many flavors:
-- a list or table row selection with an associated detail view (often forms) for the row info
-- a map or chart item selection with details per selected item
-- a tabbed pane with the individual details (often forms) per tab
+- a list or table row selection with an associated detail view for the row info (common in forms);
+- a map or chart item selection with details per selected item;
+- a tabbed pane with the individual details (often forms) per tab.
 
-OpenDolphin allows to bind the detail view against a stable _placeholder_
+OpenDolphin allows binding the detail view to a stable _placeholder_
 presentation model that is automatically synchronized (both read and write)
 with the selection.
 

--- a/docs/guide/src/guide/architecture/concepts_command_sequence.gdoc
+++ b/docs/guide/src/guide/architecture/concepts_command_sequence.gdoc
@@ -4,7 +4,7 @@ are executed asynchronously, and that commands may have an @onFinishedHandler@
 attached to it.
 
 It goes without saying that any onFinished handler is only executed after the
-controller action is finished. Therefore the name.
+controller action is finished. Hence the name, "onFinished."
 
 But despite the sequence guarantees that OpenDolphin gives you, there are
 a few things to consider about the asynchronous programming model where it is
@@ -16,7 +16,7 @@ h4. The sequence of independent commands
 
 The figure below depicts the chain of events that happens when three independent commands A, B, and C
 are sent in immediate sequence. Time goes from top to bottom and the three columns represent three concurrent
-processing units: the command queue, the controller actions (can even be remote), and the onFinished activity after the
+processing units: the command queue, the controller actions (which can even be remote), and the onFinished activity after the
 action returned.\\
 !../img/dolphin_pics/OpenDolphin-Command-Sequence-default.png!
 
@@ -39,18 +39,18 @@ At this point the B actions are processed without the effects of A being visible
 
 *4, 5, 6, 7)* Emptying out the command queue.
 
-Let's summarize the behavior so far
-- commands are always processed in the strict sequence in which they appear in the command queue
-- the onFinished handler is always executed after the respective action is finished
-- a command is only processed after the preceding one has finished its actions (but not necessarily its onFinished handlers)
-- an onFinished handler is only executed after the preceding onFinished handler is finished
+Let's summarize the behavior so far:
+- commands are always processed in the strict sequence in which they appear in the command queue;
+- the onFinished handler is always executed after the respective action is finished;
+- a command is only processed after the preceding one has finished its actions (but not necessarily its onFinished handlers);
+- an onFinished handler is only executed after the preceding onFinished handler is finished.
 
-Wouldn't it all be simpler if we waited for A to completely finish including all actions that it may possibly spawn
-before processing B like in procedural programming?
+Wouldn't it all be simpler if, as in procedural programming, we waited for A to completely finish including all actions
+that it may possibly spawn before processing B?
 *No*. This would mean that we have to block the queue during that time, which in turn would block the UI -
-and blocking the UI is the worst you can do.
+and blocking the UI is the worst thing you can do.
 
-"_But what if B depends on the effects of A_?" This is when we need the onFinishedHandler
+"_But what if B depends on the effects of A_?" This is when we need the onFinishedHandler,
 as explained in the next section.
 
 h4. When commands depend on previous ones
@@ -66,7 +66,7 @@ clientDolphin.send "A"
 clientDolphin.send "B"
 clientDolphin.send "C"
 {code}
-we do
+we write
 {code}
 clientDolphin.send "A", {
     println "Hey, we are inside the onFinished handler!"
@@ -84,21 +84,21 @@ So all relevant state is properly updated when B's actions (*6*) and onFinished 
 
 h4. Practical considerations
 
-Asynchronous programming models all have in common that when some logic is dependent on some asynchronous task
-there is a callback like the onFinished handler involved.
+Asynchronous programming models all have this in common: that when some logic is dependent on an asynchronous task,
+a callback (such as the onFinished handler) is involved.
 
 This leads to the question of what to do with a chain of dependencies. Does that automatically lead to
 deeply nested callback structures that are difficult to write and understand? Not necessarily.
 
-Various solution are on the market (e.g. "promises") but OpenDolphin has a simple way where we do not need to
-understand another concept. We simply send an extra command.
+Various solutions are on the market (e.g. "promises"), but OpenDolphin provides a simple way which doesn't require
+learning another concept. We simply send an extra command.
 
-This command doesn't need to do anything, only provide us with an onFinished handler such that we can add us
-to the command queue at the appropriate time when all is ready.
-You guessed it: such a command already exits. It is the EmptyCommand
+This command doesn't need to do anything; it merely provides us with an onFinished handler such that we can add
+a task to the command queue at the appropriate time when all is ready.
+You guessed it: such a command already exits. It is the @EmptyCommand@,
 and you can send it via the ClientDolphin's @sync@ method.
 
-So even if you have a dependency chain like A <- B <- C there is no need to write
+So even if you have a dependency chain like A <- B <- C, there is no need to write
 {code}
 clientDolphin.send "A", {
     clientDolphin.send "B", {
@@ -106,14 +106,14 @@ clientDolphin.send "A", {
     }
 }
 {code}
-but you can issue the command in this context-free fashion:
+Instead, you can issue the command in this context-free fashion:
 {code}
 clientDolphin.send "A"
 clientDolphin.sync { clientDolphin.send "B" }
 clientDolphin.sync { clientDolphin.send "C" }
 {code}
 
-Likewise, when B and C depend on A but not on each other (A <- B, A <- C) you can code this as
+Likewise, when B and C depend on A but not on each other (A <- B, A <- C), you can code this as:
 {code}
 clientDolphin.send "A"
 clientDolphin.sync {
@@ -123,7 +123,7 @@ clientDolphin.sync {
 {code}
 
 The above has the additional effect that when B has finished, C will immediately follow
-without any other command possibly sneeking in between the two,
+without any other command possibly sneaking in between the two,
 no matter whether it originates from user input or preceding commands.
 In that sense you can see the @sync@ as enclosing an atomic operation.
 

--- a/docs/guide/src/guide/architecture/concepts_commands.gdoc
+++ b/docs/guide/src/guide/architecture/concepts_commands.gdoc
@@ -4,26 +4,26 @@ All communication in OpenDolphin happens with the help of the Command Pattern.
 - Instructions from the server to the client are sent as commands.
 - The client can request additional data (beyond presentation models) with the help of a @DataCommand@.
 
-Commands are simple POJOs and there is a limited set of commands available for synchronization between
+Commands are simple POJOs, and there is a limited set of commands available for synchronization between
 client and server.
 
-On the application level only the following commands are used:
-- NamedCommand is a generic command to trigger a server side action that was registered for this name
-- DataCommand requests arbitrary data that is unrelated to presentation models
+On the application level, only the following commands are used:
+- NamedCommand is a generic command to trigger a server side action that was registered for this name.
+- DataCommand requests arbitrary data that is unrelated to presentation models.
 There is no need to implement any application specific command classes.
 
 In remote scenarios, commands are encoded and decoded via a _codec_ (e.g. JSONCoDec).
 
 A _transport_ (e.g. HttpTransport or InMemoryTransport) can be configured to use such a _codec_.
 
-Commands are used as a unit of transport since they are simple to encode/decode but
-also since they can be optimized in a number ways (buffering when the server is
-temporarily unavailable, batching, elimination of duplicates) and they open the
+Commands are used as a unit of transport not only because they are simple to encode and decode, but
+also because they can be optimized in a number ways (e.g., buffering when the server is
+temporarily unavailable, batching, eliminating duplicates) and they open the
 opportunity for later inclusion of undo/redo capabilities.
 
 Since commands are sent asynchronously, one cannot wait for a command to complete.
 When sending a command, though, one can provide an @OnFinishedHandler@ that is called back
-as soon as the command has returned. The list of all presentation models that were affected by that
-command is passed as argument into the callback methods.
+as soon as the command has returned. The list of all presentation models affected by that
+command is passed as an argument into the callback methods.
 
 See also [Usage|Command].

--- a/docs/guide/src/guide/architecture/concepts_discussion.gdoc
+++ b/docs/guide/src/guide/architecture/concepts_discussion.gdoc
@@ -1,36 +1,36 @@
-No architecture documentation is complete without explaining the rationale
+No documentation of architecture is complete without explaining the rationale
 behind the decisions - which alternatives were considered and why other
 approaches were not chosen.
 
 To that end, we would like to go through a number of questions that we had
-to answer when designing OpenDolphin and we will do so in the style of a discussion.
+to answer when designing OpenDolphin, and we will do so in the style of a discussion.
 
-h4. Why choosing presentation model as the main pattern?
+h4. Why choose "presentation model" as the main pattern?
 
-There would have been other candidates: Model View Presenter, Passive View,
+There were indeed other candidates: Model View Presenter, Passive View,
 Supervising Controller, Event Bus, and many more.
 
-All such patterns have their benefits and particularly a distributed event system
+All such patterns have their benefits, and particularly a distributed event system
 would have played well with the intended remoting capabilities.
 
-It were mainly the good experiences we made with the presentation model pattern
+It was mainly due to the good experiences we had with the presentation model pattern
 in a number of large event-based systems that it became our first choice. The distinction
 between _what_ and _how_ turned out to be easier to explain than other
 approaches. It always gave the team good guidance when developing the system.
-Also we had the honor to have the grandmaster of this pattern Dr. Dieter Holz
-in the team.
+Also, we had the honor to have the grandmaster of this pattern, Dr. Dieter Holz,
+on the team.
 
-Following the _pattern_ was always easy enough even though it required
+Following the _pattern_ was always easy enough, even though it required
 writing the respective classes all over again with each new project.
 As soon as we found out how to generalize the pattern and combine it with
 stable bindings and reliable remoting, we never looked back.
 
 h4. Why so much attention on stable bindings?
 
-Our first attempt of a canonical implementation of the presentation model pattern
+Our first attempt at a canonical implementation of the presentation model pattern
 (which is still around under the name [GRASP|https://github.com/canoo/grasp])
-turned out to become really complex and not reliable enough
-to build solid remoting upon because of the intricacies of "rebinding" when
+turned out to be really complex and not a reliable enough platform
+on which to build solid remoting, because of the intricacies of "rebinding" when
 switching references to attributes.
 
 Let's say a text field should bind against the first name of person A.
@@ -40,7 +40,7 @@ listeners and informing the server. We lost many a night's sleep over this
 seemingly simple issue.
 And it gets worse when you don't have a generic implementation.
 
-As soon as Andres Almiray discovered how to do stable bindings,
+But as soon as Andres Almiray discovered how to do stable bindings,
 everything seemed to just fall in place.
 
 h4. Why generic implementations?
@@ -48,22 +48,22 @@ h4. Why generic implementations?
 Presentation models, attributes, and commands are all generic.
 
 The alternative would have been to provide superclasses that
-are to be extended with custom state and behavior.
+had to be extended with custom state and behavior.
 
 With generic implementations, we not only have the benefit
-of fewer classes in the system but more importantly
+of fewer classes in the system, but more importantly,
 less _structural duplication._
 
 We also avoid all the versioning problems that inevitably arise
 with shared application classes between client and server.
 
-But most of all, with generic implementations it is much easier
+But most of all, with generic implementations, it is much easier
 to control the system. With subclasses, you never quite know what
-they are doing in extend and whether e.g. it is now safe to
+functionality they extend and whether e.g. it is now safe to
 delete them. Generic implementations are much easier to keep cohesive.
 
 By the same train of thought, generic implementations are easier
-to build upon. Since you exactly know what they are and what they do,
+to build upon. Since you know exactly what they are and what they do,
 it is much easier to build convenience methods in the facade, e.g.
 to provide new bindings to yet unknown UI toolkits.
 
@@ -73,29 +73,29 @@ non-Java clients (web and mobile).
 h4. Why not simply using REST?
 
 OpenDolphin is actually free to use a REST _transport_ if so
-configured (while the current HttpTransport is actually using
-only the POST method and therefore doesn't really qualify as pure REST).
+configured. (The current HttpTransport is actually using
+only the POST method and therefore doesn't really qualify as pure REST.)
 
 Even though these are not necessarily constituent features of REST, people often understand REST as
-- a stateless server
-- message-passing communication (all required info is transferred with every request)
+- a stateless server;
+- message-passing communication (all required info is transferred with every request).
 
-This has obvious benefits and may be the right choice in many scenarios
-but it doesn't allow to have application logic on the server
+This has obvious benefits and may be the right choice in many scenarios,
+but it doesn't permit having application logic on the server
 (only data-access logic, possibly wrapped in services).
 You end up with a "fat" client that contains the major part of the application logic.
 
-With OpenDolphin the server always knows the exact state of the client
+With OpenDolphin, the server always knows the exact state of the client
 and can act accordingly, sending the least amount of data.
 
 As compared to REST, OpenDolphin users typically have to wait less, because
-- data sending is done most often without the user noticing (asynchronously)
-- when the user really has to wait for the server, the package size is as small as possible
-- since client and server know the same state, they only have to send diffs
-- small packages (most often only one tcp/ip package) have the lowest latency
+- data sending is done most often without the user noticing (asynchronously);
+- when the user really has to wait for the server, the package size is as small as possible;
+- since client and server know the same state, they only have to send diffs;
+- small packages (most often only one TCP/IP package) have the lowest latency.
 
 With the application running on the server, OpenDolphin is in full control
-what the client displays - just like with traditional HTML applications
+of what the client displays, just like with traditional HTML applications
 (but with richer visualisation capabilities). When a new server version is deployed,
 all clients are instantly controlled by the new behavior.
 

--- a/docs/guide/src/guide/architecture/concepts_model_store.gdoc
+++ b/docs/guide/src/guide/architecture/concepts_model_store.gdoc
@@ -1,6 +1,6 @@
 Any reasonably sized UI will have not only single presentation models but many of the same type.
 
-Let's assume that the application displays a list of vehicles where each vehicle is a
+Let's assume that the application displays a list of vehicles, where each vehicle is a
 presentation model instance of type "vehicle".
 
 The list view must add a new row whenever a new vehicle becomes available and must
@@ -12,17 +12,30 @@ be notified whenever a presentation model is added to or removed from the store.
 The model store defines the managed object space for presentation models.
 
 There are two such stores: one on the client and one on the server.
-Both are automatically synchronized by OpenDolphin.
+These are automatically synchronized by OpenDolphin.
 
 Conceptually, one can see the model store as
-- a distributed, in-memory, no-sql database with only two tables (presentation model and attribute)
-- a specialized event bus (event provider is only the store itself and only ModelStoreEvents are issued)
+- a distributed, in-memory, no-sql database with only two tables (presentation model and attribute);
+- a specialized event bus (event provider is only the store itself and only ModelStoreEvents are issued).
+
+Continuing the database analogy, the Presentation Model "table" contains columns for:
+- a unique identifier, and
+- an optional type.
+
+The Attribute "table" contains columns for:
+- a unique identifier;
+- a property name;
+- a tag, which defaults to "VALUE";
+- an optional qualifier;
+- the current value, which may be a String, Number, Character, Boolean, or Date;
+- the base value, used to determine if the current value is dirty; and
+- the ID of the presentation model to which the attribute belongs.
 
 The application programmer should not access the model store directly
-but only through the facade layer, see [Usage|Dolphin].
+but only through the facade layer; see [Usage|Dolphin].
 
 The model store is used internally as a value change listener to all known attributes in order to
-- consistently update all attributes of the same _qualifier_
-- notify the server about changes
+- consistently update all attributes of the same _qualifier_;
+- notify the server about changes.
 
-Now, let's have a look how the client-server split is designed in OpenDolphin.
+Now let's have a look how the client-server split is designed in OpenDolphin.

--- a/docs/guide/src/guide/architecture/concepts_presentation_model.gdoc
+++ b/docs/guide/src/guide/architecture/concepts_presentation_model.gdoc
@@ -42,9 +42,9 @@ h4. What is special
 - They allow [stable bindings|guide:concepts_binding].
 - They are _flat._ Their attributes contain no object references, only primitive values. There is no object graph.
 - In particular, they do not maintain an object reference to a domain model (but maybe a key).
-- They are _shared_ between a client and a server. Dolphin cares for consistent synchronization.
+- They are _shared_ between a client and a server. Dolphin ensures consistent synchronization.
 - They live in a managed object space. All instances are known and can be retrieved by their characteristics.
-- They have a unique _id_, which either the application programmer provides or is automatically assigned otherwise.
+- They have a unique _id_, which either the application programmer provides or is automatically assigned.
 - They optionally have a _type_ parameter for logical grouping.
 
 See also: [Usage|PresentationModel] and [API doc|api:org.opendolphin.core.PresentationModel].
@@ -55,4 +55,4 @@ When there is the least bit of business logic, it goes into an action.
 Actions live in controller classes of the server module.
 
 There is a small fraction of logic that resides on the client, which is
-_view_ logic like e.g. for calculating component bounds when layouting.
+_view_ logic like e.g. for calculating component bounds when laying out the view.

--- a/docs/guide/src/guide/architecture/concepts_remoting.gdoc
+++ b/docs/guide/src/guide/architecture/concepts_remoting.gdoc
@@ -1,23 +1,76 @@
 A dolphin application has a client and a server module.
-As we will see in [remote config|guide:config_remote] and [standalone config|guide:config_standalone]
+As we will see in [remote config|guide:config_remote] and [standalone config|guide:config_standalone],
 this does not necessarily mean that client and server live in different VMs, but they can.
 
-With OpenDolphin, the client is responsible to visualize presentation models,
-the server is responsible to manage the presentation model data.
+With OpenDolphin, the client is responsible for visualizing presentation models,
+and the server is responsible for managing the presentation model data.
 
-In order to keep client and server [model store|guide:concepts_model_store] consistent,
-one must be chosen as the master and the dolphin team has chosen the client to be that master.
+OpenDolphin provides two techniques to keep client and server [model store|guide:concepts_model_store] synchronized.
+You may use either technique or mix the two.
 
-All changes *first* happen *on the client*. Then the server is notified, and he updates automatically.
+h4. First technique: Client initiates all changes to the model store
+Using the first technique, the client model store is regarded as the master.
+All changes *first* happen *on the client*. Then the server is notified, and it automatically makes identical changes
+to its model store.
 
 Any server-side changes happen by the server sending a [command|guide:concepts_commands] to the client
-instructing him which change to apply.
+instructing it which change to apply.
 
-All communication between client and server happens *asynchronously* no matter whether an in-memory or
+To use the first technique, restrict server-side code to using <name>Command methods. (See DefaultServerDolphin class
+for a list of these commands.)  These *Command methods merely send a command from the server to the client;
+the client will execute the command against the client's model store, and send a command back to the server which
+will cause the server's model store to synchronize.
+
+h4. Second technique: Client or Server may initiate changes to the model store
+Using the second technique, the programming model on the server side becomes equivalent to that of the client side.
+As an example: you no longer need to call
+{code}
+// send client a command to change the value of an attribute;
+// the client will do so and send an identical command back to the server,
+// at which time the server will make the same change to the attribute in its model store:
+changeValueCommand(attribute, value);
+{code}
+on the server side, but you can directly use
+{code}
+// immediate state change
+attribute.setValue(value);
+{code}
+which will immediately change the attribute value on the server side _and_ send the appropriate command
+to the client.
+
+This approach has the following properties:
+- any trailing code on the server side can now rely on the updated state
+- any property change listeners are immediately called
+- any model store listeners are immediately called
+
+{note}
+You get a full reactive *event-driven programming model* in the normally request-response oriented
+Java enterprise world.
+{note}
+
+{warning}
+The "strong" approach of the first technique
+(i.e., never changing the server state but only sending commands to the client)
+has the (undocumented) effect that server actions are transactional: in case of server side exceptions,
+no change is sent to the client. Either all or no changes are executed.
+
+You can still have the same behavior by restricting yourself to the first technique;
+but if you use the second technique, changes will no
+longer be transactional and server-side exceptions need application-specific handling.
+{warning}
+The "strong" approach of the first technique can easily enforce that the client is always the master.
+As soon as you do any immediate server-side change, there may be conflicts when client-state changes
+while the same state is modified on the server.
+
+OpenDolphin detects these conflicts and ensures that the client side always wins.
+
+h4. Communication and Threading
+Regardless of the technique used, all communication between client and server happens *asynchronously*,
+no matter whether an in-memory or
 remote configuration is used.
 
 Despite the asynchronous communication, OpenDolphin guarantees notification delivery in the same
-sequence as they originated.
+sequence as the command messages originated.
 
 OpenDolphin assumes the client to have an event model and the server to live in a request-response model.
 OpenDolphin bridges these two worlds.
@@ -25,13 +78,13 @@ OpenDolphin bridges these two worlds.
 Despite the asynchronous communication between client (view) and server (controller), all
 processing that takes place as a result of this communication is automatically executed inside the client's
 UI thread.
-Especially all changes to the client model store, client presentation models, and attributes are subject to
-this thread-confined approach. Thus, all binding events will be fired in the UI thread and the
+In particular, all changes to the client model store, client presentation models, and attributes are subject to
+this thread-confined approach. Thus, all binding events will be fired on the UI thread, and the
 views are automatically updated correctly.
 
-Likewise, on the server (controller) side all actions are executed in a thread-confined manner, i.e.
-there is at most one action at a time being executed and per roundtrip all actions are executed in the
+Likewise, on the server (controller) side, all actions are executed in a thread-confined manner, i.e.
+there is at most one action at a time being executed, and per round trip, all actions are executed in the
 same thread.
 
-With the clear structure and division of responsibilities that OpenDolphin imposes onto the application
-a lot of otherwise common headaches around proper thread handling disappear.
+With the clear structure and division of responsibilities that OpenDolphin imposes on the application,
+many otherwise common headaches around proper thread handling disappear.

--- a/docs/guide/src/guide/howto.gdoc
+++ b/docs/guide/src/guide/howto.gdoc
@@ -7,10 +7,10 @@ We implement a very simple application that contains only one text field and two
 Both buttons are only enabled if there is really something to save/reset, i.e. the field value is dirty.
 The dirty state is also visualized via a CSS class (background color changes). Resetting triggers a 'shake' animation.
 
-Steps 0 to 4 solely live in the "combined" module for a simple jumpstart
+Steps 0 to 4 live solely in the "combined" module for a simple jumpstart
 before we properly split client and server in step 5 and only keep a starter class in "combined".
 
-Step 7 produces a WAR file that you can deploy in an application server (e.g. Tomcat) and the code that starts the client moves to the "client" module.
+Step 7 produces a WAR file that you can deploy in an application server (e.g. Tomcat), and the code that starts the client moves to the "client" module.
 
 h4. Setup and start of a basic JavaFX view
 
@@ -32,7 +32,7 @@ We start our development in the "combined" module with the simplest possible Jav
 The class has a main method such that you can start it from inside the IDE.
 Otherwise use the command line launcher as described in the readme.
 
-When your setup is correct, it should appear on your screen like:
+When your setup is correct, it should appear on your screen like this:
 
 !../img/dolphin_pics/step0.png!
 

--- a/docs/guide/src/guide/howto/step1.gdoc
+++ b/docs/guide/src/guide/howto/step1.gdoc
@@ -1,8 +1,8 @@
 We stay in the "combined" module and enhance the JavaFX view
-[step1.JumpStart|https://github.com/canoo/DolphinJumpStart/blob/master/combined/src/main/java/step_1/JumpStart.java].
+[step1.JumpStart|https://github.com/canoo/DolphinJumpStart/blob/master/combined/src/main/java/step_1/JumpStart.java]
 just slightly with a TextField and a Button that prints the content of the TextField when clicked.
 
-The application should appear on your screen like: \\
+The application should appear on your screen like this: \\
 !../img/dolphin_pics/step1.png!
 
 The code now contains references to the widgets
@@ -16,7 +16,7 @@ and an action handler
 {code}
 button.setOnAction(new EventHandler<ActionEvent>() {
     public void handle(ActionEvent actionEvent) {
-        System.out.println("text field contains: "+field.getText());
+        System.out.println("text field contains: " + field.getText());
     }
 });
 {code}

--- a/docs/guide/src/guide/howto/step2.gdoc
+++ b/docs/guide/src/guide/howto/step2.gdoc
@@ -2,7 +2,7 @@ In step 2 we refactor the JavaFX application into
 [step2.JumpStart|https://github.com/canoo/DolphinJumpStart/blob/master/combined/src/main/java/step_2/JumpStart.java]
 to make use of OpenDolphin.
 
-The visual appearance and the behavior has not changed
+The visual appearance and the behavior has not changed:
 
 !../img/dolphin_pics/step1.png!
 
@@ -22,14 +22,15 @@ PresentationModel input = clientDolphin.presentationModel("input", new ClientAtt
 Note that we do _not_ define a "JumpStartPresentationModel" since presentation models in OpenDolphin
 are totally generic.
 
-Behind the scenes (no pun intended) happens quite a lot:
-* the input presentation model is added to the client model store (with indexes being updated)
-* the client dolphin registers itself as a property change listener to the value of the "text" attribute
-* the server dolphin is asynchronously notified about the creation, which you can observe in the logs
+"clientDolphin" is the interface to Dolphin used by client-side code. When "clientDolphin.presentationModel()" is called,
+behind the scenes (no pun intended), quite a lot happens:
+* the input presentation model is added to the client model store (with indexes being updated);
+* the client dolphin registers itself as a property change listener to the value of the "text" attribute;
+* the server dolphin is asynchronously notified about the creation, which you can observe in the log output;
 * the server dolphin asynchronously updates its model store accordingly.
 
 While this happens, we bind the text property of the TextField (this is a JavaFX property) to the "text" attribute of
-the input presentation model
+the input presentation model:
 
 {code}
 JFXBinder.bind("text").of(field).to("text").of(input);
@@ -45,8 +46,9 @@ bind "text" of field to "text" of input
 {code}
 {note}
 
-Finally, the action handler that was part of the (client) view before now moves to the
-(server) controller. We register it as an "action" on the server-dolphin.
+Finally, the action handler that was part of the view (i.e., the client) before now moves to the
+controller (i.e., the server). We register it as an "action" on the server-dolphin (which is the interface to Dolphin
+used by server-side code.)  We will name this action "PrintText", as follows:
 
 {code}
 config.getServerDolphin().action("PrintText", new NamedCommandHandler() {
@@ -61,10 +63,10 @@ config.getServerDolphin().action("PrintText", new NamedCommandHandler() {
 Note that the (client) view and the (server) controller *do not share any objects!*
 {note}
 
-The dolphin server action must therefore ask the server-dolphin for the "text" value
-of the "input" presentation model before he can print it.
+The dolphin server action (in handleCommand) must therefore ask the server-dolphin for the "text" value
+of the "input" presentation model before it can be printed.
 
-Triggering the server action becomes the remaining statement in the button's onAction handler.
+Triggering the server action is done in the button's onAction handler:
 
 {code}
 button.setOnAction(new EventHandler<ActionEvent>() {
@@ -74,7 +76,7 @@ button.setOnAction(new EventHandler<ActionEvent>() {
 });
 {code}
 
-When we now start the application we see in the log:
+When we now start the application, we see the following lines appear in the log:
 
 {code}
 [INFO] C: transmitting Command: CreatePresentationModel pmId input pmType null attributes [[propertyName:text, id:761947653, qualifier:null, value:null, tag:VALUE]]
@@ -82,13 +84,13 @@ When we now start the application we see in the log:
 [INFO] C: transmitting Command: ValueChanged attr:761947653, null ->
 [INFO] S:     received Command: ValueChanged attr:761947653, null ->
 [INFO] C: server responded with 0 command(s): []
-[INFO] C: server responded with
 {code}
 
-The C prefixes illustrate statements that are logged from the Client. S prefixes denote statements that are logged from the Server.
+The "C:" prefixes illustrate statements that are logged from the Client. "S:" prefixes denote statements that are logged from the Server.
 
-The log statements are telling us that the presentation model has been created and the value changed from null to an empty String,
-the JavaFX default value for text fields.
+The log statements are telling us that the presentation model has been created on the client (and duplicated on the
+server); and that the value changed from null to an empty String,
+the JavaFX default value for text fields, first on the client, then on the server.
 
 Let's enter "abcd":
 
@@ -109,7 +111,7 @@ Let's enter "abcd":
 
 Every single change is asynchronously sent to the server dolphin. Note that the user interface *does not block*.
 
-Finally, we hit the button
+Finally, we press the button:
 
 {code}
 [INFO] C: transmitting Command: PrintText
@@ -118,11 +120,11 @@ server text field contains: abcd
 [INFO] C: server responded with 0 command(s): []
 {code}
 
-Our server action performs its printing action *asynchronously*, particularly not in the UI thread!
-You can see the asynchronous behavior by the line ordering in the log above.
+Our server action performs its printing action *asynchronously*, in particular, not in the UI thread!
+You can see the asynchronous behavior exhibited in the line ordering in the log above.
 If it were synchronous, lines 2 and 3 would never be in this order.
 
-Note that even though all the logic runs in-memory, we have the first benefit from OpenDolphin:
+Note that even though all the logic runs in-memory, we see the first benefit from OpenDolphin:
 
 {note}
 All actions are executed *asynchronously outside the UI thread*.\\

--- a/docs/guide/src/guide/howto/step3.gdoc
+++ b/docs/guide/src/guide/howto/step3.gdoc
@@ -1,8 +1,8 @@
 In
 [step3.JumpStart|https://github.com/canoo/DolphinJumpStart/blob/master/combined/src/main/java/step_3/JumpStart.java]
-we first cleanup the code such that it becomes more obvious, which part belongs to the (client) view and the
+we first clean up the code to clarify which part belongs to the (client) view and the
 (server) controller. In the first place, OpenDolphin leads to a _logical_ view-controller distinction and
-client-server split. The only thing that is optionally shared are constants.
+client-server split. The only things that are optionally shared are constants.
 
 It is always a good idea to refactor literal values into constants, especially if they
 are used in more than one place for a unique purpose.
@@ -25,8 +25,8 @@ public JumpStart() {
 }
 {code}
 
-This leaves the "start" method with "view" responsibilities only:
-the initial contruction and separate method calls for binding and registering actions.
+This leaves the "start" method with "view" responsibilities only, namely,
+the initial construction and separate method calls for binding and registering actions.
 
 {code}
 @Override
@@ -52,7 +52,8 @@ public void start(Stage stage) throws Exception {
 }
 {code}
 
-We add an additional labeled checkbox to visualize the status: whether the text field - or more precisely the dolphin attribute that backs it - is considered "dirty".
+We add an additional labeled checkbox to visualize the "dirty" status of the text field (or, more precisely,
+the dolphin attribute that backs it.)
 
 !../img/dolphin_pics/step3.png!
 

--- a/docs/guide/src/guide/howto/step4.gdoc
+++ b/docs/guide/src/guide/howto/step4.gdoc
@@ -31,6 +31,6 @@ You probably guessed that this code looks nicer in Groovy. Yes, it does:
 bindInfo "dirty" of textAttributeModel using { state -> !state } to "disabled" of button
 {code}
 
-Once the code is nicely broken into independent parts we can put the various parts into separate modules
+Once the code is nicely broken into independent parts, we can put the various parts into separate modules
 for better dependency management.
 

--- a/docs/guide/src/guide/howto/step5.gdoc
+++ b/docs/guide/src/guide/howto/step5.gdoc
@@ -1,7 +1,7 @@
 Step 5 distributes the code into multiple modules (IntelliJ IDEA parlance) or projects/subprojects
 (Gradle, Maven, Eclipse parlance). We use the more generic word "module".
 
-The *combined* module depends on both client and server and is used for starting the application
+The *combined* module depends on both client and server, and is used for starting the application
 with the *in-memory* configuration.
 The sole class that lives in this module is the starter class
 [step5.TutorialStarter|https://github.com/canoo/DolphinJumpStart/blob/master/combined/src/main/java/step_5/TutorialStarter.java]
@@ -13,9 +13,9 @@ The *client* module (or "view" module if you wish) contains the
 [step5.TutorialApplication|https://github.com/canoo/DolphinJumpStart/blob/master/client/src/main/java/step_5/TutorialApplication.java]
 view.
 
-You can see that the view code is pretty much the same as our old application code but contains the view specific
+You can see that the view code is pretty much the same as our old application code, but contains the view specific
 parts only. There is one additional change, though. When the button has been pressed and the command has been
-executed on the server we would like to interpret the current content of the text field as the new base value just as
+executed on the server, we would like to interpret the current content of the text field as the new base value just as
 if the error-free execution of the command would imply a correct "save".
 The "disabled" state of the button will reflect the new non-dirty state.
 
@@ -32,18 +32,18 @@ public void handle(ActionEvent actionEvent) {
 {code}
 
 Please note that the onFinished handler will be called _asynchronously inside_ the UI thread. It may trigger
-changes in the model store, which may lead to changes in the display and any such changes _must_ occur in the
+changes in the model store, which may lead to changes in the display; and any such changes _must_ occur in the
 UI thread.
 
 The *server* module (or "controller" module if you wish) contains the
 [step5.TutorialAction|https://github.com/canoo/DolphinJumpStart/blob/master/server/src/main/java/step_5/TutorialAction.java]
 controller.
 
-Both, client and server depend on the *shared* module, which makes the
+Both client and server depend on the *shared* module, which makes the
 [step5.TutorialConstants|https://github.com/canoo/DolphinJumpStart/blob/master/shared/src/main/java/step_5/TutorialConstants.java]
 known to both parties. The shared module itself does not depend on anything.
 
-The code that contains the shared constants now also cares for the uniqueness of
+The code that contains the shared constants also ensures the uniqueness of
 certain Strings, particularly of IDs used to retrieve presentation models and named commands.
 
 {code}
@@ -56,20 +56,20 @@ private static String unique(String key) {
 }
 {code}
 
-Splitting four classes into four different modules may look a bit over-engineered at this point
-but it is an indispensible step before we can go into true remoting and before we can instantly
+Splitting four classes into four different modules may look a bit over-engineered at this point,
+but it is an indispensible step before we can go on to true remoting and before we can instantly
 switch between in-memory- and client-server-mode.
 
-If you fear that this is too much work for setting up the directory structure or the
-build-time dependencies: simply unzip one of the
+If you fear that it's too much work to set up the directory structure or the
+build-time dependencies, simply unzip one of the
 [project templates|https://github.com/canoo/DolphinJumpStart/tree/master/dist]
 and you are good to go.
 
 We get the following benefits:
-* ability to start the code _unmodified_ with different configurations (in-memory or client-server)
-* clear and minimal dependencies when building
-* a minimum of shared code (only the constants) to express semantic dependencies as syntatic dependencies
+* ability to start the code _unmodified_ with different configurations (in-memory or client-server);
+* clear and minimal dependencies when building;
+* a minimum of shared code (only the constants) to express semantic dependencies as syntactic dependencies;
 * actions cannot "accidentally" reach out to view code. The widget set is not even on the classpath!
-* actions cannot possibly block the UI thread
-* view changes are _always_ displayed correctly since they happen in the UI thread
-* the separation of responsibilities is enforced by the dependency structure
+* actions cannot possibly block the UI thread;
+* view changes are _always_ displayed correctly since they happen in the UI thread;
+* the separation of responsibilities is enforced by the dependency structure.

--- a/docs/guide/src/guide/howto/step6.gdoc
+++ b/docs/guide/src/guide/howto/step6.gdoc
@@ -5,7 +5,7 @@ and some tweaks to the view such that it appears like
 !../img/dolphin_pics/step6.png!
 
 The true value of the change is not visible in a screenshot, though, since it is in the behavior.
-The modified background color of the text field appears as soon as it becomes dirty and is
+The modified background color of the text field appears as soon as it becomes dirty, and is
 set back to the original state when the dirty state is set back.
 
 To make this happen, we enhance the binding with a little trick in the converter that
@@ -40,14 +40,14 @@ should we later decide to visualize the dirty state differently.
 }
 {code}
 
-Once we have the view code so nicely refactored to be free of any other responsibility,
+Once we have the view code so nicely refactored as to be free of any other responsibility,
 we can spend some extra brain cycles on improving the look and feel, both when
 visualizing state but also for emphasizing state transitions.
 
 h4. Reset by shaking the field
 
 When we click the "reset" button, the dirty value is replaced by the last known base value
-and a "shake" animation is played on the text field.
+and a "shake" animation is performed on the text field.
 
 A shake is a rotation of the field around its center by an angle from -3 to +3 degrees.
 This is done 3 times during 100 ms each. It makes for a funny effect.
@@ -82,6 +82,6 @@ that contains only one application-specific action and the
 [step6.TutorialDirector|https://github.com/canoo/DolphinJumpStart/blob/master/server/src/main/java/step_6/TutorialDirector.java]
 who selects which actors should appear in the play, i.e. registers actions with the server dolphin.
 
-This distinction makes it easier to evolve the application when new actions come into play since the
-server adapter (servlet) doesn't have to change when the list of actions changes as we will see in a minute.
+This distinction makes it easier to evolve the application when new actions come into play, since the
+server adapter (servlet) doesn't have to change when the list of actions changes, as we will see in a minute.
 

--- a/docs/guide/src/guide/howto/step7.gdoc
+++ b/docs/guide/src/guide/howto/step7.gdoc
@@ -72,8 +72,8 @@ stub or mock implementation for the service interface.
 
 h2. Final considerations
 
-This has been a very small application to start with but we have touched all relevant bases from
-starting with a standalone view, through proper modularization, up to a remote client-server setup.
+This has been a very small application to start with, but we have touched all relevant bases, from
+starting with a standalone view, through proper modularization, and finishing with a remote client-server setup.
 
 We have used a "bare-bones" setup with 100% pure Java and a no dependencies beyond Java 7+
 and OpenDolphin.
@@ -93,5 +93,5 @@ Of course, a full application has more use cases than managing a single text fie
 
 The [use cases and demos|guide:demos] chapter leads you through the typical use cases of
 master-detail views, form-based pages, collections of data, lazy loading, shared attributes,
-CRUD operations, and much more by describing the use case, explaining the
+CRUD operations, and many more by describing the use case, explaining the
 OpenDolphin approach of solving it, and pointing to the respective demos.

--- a/docs/guide/src/guide/introduction.gdoc
+++ b/docs/guide/src/guide/introduction.gdoc
@@ -1,19 +1,18 @@
-[Canoo|http://www.canoo.com] initiated the Dolphin project since we had recognized that many of our customers share a common quest:\\
-Keeping the *application logic* on the *server* but *presenting* it with all the capabilities of the *client* device.
+[Canoo|http://www.canoo.com] initiated the Dolphin project because we recognized that many of our customers share a common quest:\\
+keeping the *application logic* on the *server*, but *presenting* it with all the capabilities of the *client* device.
 
 Dolphin is a remoting solution that bridges the world of Enterprise Java and Desktop Java.
-Unlike most REST approaches, it doesn't confine the server to be a data source only.
+Unlike most REST approaches, it doesn't restrict the server to be a data source only.
 
-Instead, with Dolphin your server-side business logic controls a shared presentation model.
+Instead, with Dolphin, your server-side business logic controls a shared presentation model.
 The client displays the Dolphin state in all its beauty.
 
-The figure below shows how client and server connect via Dolphin's shared presentation model
-followed by some introductory slides on the topic.
+The figure below shows how client and server connect via Dolphin's shared presentation model.
 
 !../img/dolphin_pics/dolphin.002.png!
 
-In terms of Model-View-Controller (MVC) one can see in the figure above that Dolphin puts the
-*View* responsibility on the client but leaves the *controlling* logic on the server.
+In terms of Model-View-Controller (MVC), one can see in the figure above that Dolphin puts the
+*View* responsibility on the client, but leaves the *controlling* logic on the server.
 The *model* (here in the sense of a _presentation_ model, not a domain model) is shared.
 
 This is shown in even more detail below.
@@ -24,5 +23,4 @@ This is shown in even more detail below.
 
 !../img/dolphin_pics/dolphin.005.png!
 
-Throughout this documentation, we will refer to this introduction and especially the
-section on [architecture|guide:architecture] expands on the value of clean structures.
+In particular, the section on [architecture|guide:architecture] expands on the value of clean structures.

--- a/docs/guide/src/guide/introduction/changes.gdoc
+++ b/docs/guide/src/guide/introduction/changes.gdoc
@@ -26,7 +26,7 @@ changeValue(attribute, value);
 // to be replaced with
 changeValueCommand(attribute, value);
 {code}
-on the server side but you can directly use
+on the server side, but you can directly use
 {code}
 // immediate state change
 attribute.setValue(value);

--- a/subprojects/combined/src/main/groovy/org/opendolphin/core/comm/DefaultInMemoryConfig.groovy
+++ b/subprojects/combined/src/main/groovy/org/opendolphin/core/comm/DefaultInMemoryConfig.groovy
@@ -23,6 +23,12 @@ import org.opendolphin.core.client.comm.InMemoryClientConnector
 import org.opendolphin.core.server.DefaultServerDolphin
 import org.opendolphin.core.server.ServerDolphinFactory
 
+/**
+ * Base class for running a client and server dolphin inside the same VM.
+ * <p/>
+ * Subclasses JavaFxInMemoryConfig and SwingInMemoryConfig additionally set the threading model
+ * as appropriate for the UI (JavaFX or Swing, respectively.)
+ */
 class DefaultInMemoryConfig {
 
     ClientDolphin clientDolphin = new ClientDolphin()

--- a/subprojects/demo-javafx/client/src/main/groovy/org/opendolphin/demo/MasterDetailView.groovy
+++ b/subprojects/demo-javafx/client/src/main/groovy/org/opendolphin/demo/MasterDetailView.groovy
@@ -124,30 +124,30 @@ class MasterDetailView {
             def inverter = { boolean enableStatus -> !enableStatus }
             // all the bindings ...
             bind ATT_NAME           of dataMold to FX.TEXT of nameField
-            bind ATT_NAME, ENABLED  of dataMold to FX.DISABLE of nameField, inverter
+            bind ATT_NAME, ENABLED  of dataMold using inverter to FX.DISABLE of nameField
             bind ATT_NAME, LABEL    of dataMold to FX.TEXT of nameLabel
             bind ATT_NAME, LABEL    of dataMold to FX.TEXT of nameCol
             bind FX.TEXT            of nameField to ATT_NAME of dataMold
 
             bind ATT_RANK           of dataMold to FX.TEXT of rankField
-            bind ATT_RANK, ENABLED  of dataMold to FX.DISABLE of rankField, inverter
+            bind ATT_RANK, ENABLED  of dataMold using inverter to FX.DISABLE of rankField
             bind ATT_RANK, LABEL    of dataMold to FX.TEXT of rankLabel
             bind ATT_RANK, LABEL    of dataMold to FX.TEXT of rankCol
 
             bind ATT_COUNTRY            of dataMold to FX.TEXT of countryField
-            bind ATT_COUNTRY, ENABLED   of dataMold to FX.DISABLE of countryField, inverter
+            bind ATT_COUNTRY, ENABLED   of dataMold using inverter to FX.DISABLE of countryField
             bind ATT_COUNTRY, LABEL     of dataMold to FX.TEXT of countryLabel
 
             bind ATT_YEAROFBIRTH            of dataMold to FX.TEXT of yearOfBirthField
-            bind ATT_YEAROFBIRTH, ENABLED   of dataMold to FX.DISABLE of yearOfBirthField, inverter
+            bind ATT_YEAROFBIRTH, ENABLED   of dataMold using inverter to FX.DISABLE of yearOfBirthField
             bind ATT_YEAROFBIRTH, LABEL     of dataMold to FX.TEXT of yearOfBirthLabel
 
             bind ATT_MATCHESFIFA            of dataMold to FX.TEXT of matchesFIFAField
-            bind ATT_MATCHESFIFA, ENABLED   of dataMold to FX.DISABLE of matchesFIFAField, inverter
+            bind ATT_MATCHESFIFA, ENABLED   of dataMold using inverter to FX.DISABLE of matchesFIFAField
             bind ATT_MATCHESFIFA, LABEL     of dataMold to FX.TEXT of matchesFIFALabel
 
             bind ATT_MATCHESRSSSF           of dataMold to FX.TEXT of matchesRSSSFField
-            bind ATT_MATCHESRSSSF, ENABLED  of dataMold to FX.DISABLE of matchesRSSSFField, inverter
+            bind ATT_MATCHESRSSSF, ENABLED  of dataMold to using inverter FX.DISABLE of matchesRSSSFField
             bind ATT_MATCHESRSSSF, LABEL    of dataMold to FX.TEXT of matchesRSSSFLabel
 
             table.items = observableList

--- a/subprojects/server/src/main/groovy/org/opendolphin/core/server/ServerDolphinFactory.java
+++ b/subprojects/server/src/main/groovy/org/opendolphin/core/server/ServerDolphinFactory.java
@@ -1,16 +1,28 @@
+/**
+ * Created by hendrikebbers on 20.01.15.
+ */
 package org.opendolphin.core.server;
 
 /**
- * Created by hendrikebbers on 20.01.15.
+ * A factory class to create a ServerDolphin object.
  */
 public class ServerDolphinFactory {
 
     private ServerDolphinFactory() {}
 
+    /**
+     * Creates a default ServerDolphin object containing a default ServerModelStore and ServerConnector.
+     */
     public static ServerDolphin create() {
         return new DefaultServerDolphin();
     }
 
+    /**
+     * Creates a default ServerDolphin object using the supplied model store and server connector.
+     * @param serverModelStore
+     * @param serverConnector
+     * @return
+     */
     public static ServerDolphin create(ServerModelStore serverModelStore, ServerConnector serverConnector) {
         return new DefaultServerDolphin(serverModelStore, serverConnector);
     }


### PR DESCRIPTION
- Rewrite section in concepts_remoting.gdoc that takes functionality of release 0.10 into account (allowing server-side changes to model store to happen before client-side changes.) 
- Clean up introduction, architecture and How-To sections of the online guide; fix typos & grammar; improve readability of English.