### PR TITLE
the new en/decoding from 7fd89dd actually does not work

### DIFF
--- a/subprojects/shared/src/main/groovy/org/opendolphin/core/comm/JsonCodec.groovy
+++ b/subprojects/shared/src/main/groovy/org/opendolphin/core/comm/JsonCodec.groovy
@@ -98,6 +98,14 @@ class JsonCodec implements Codec {
                     return
                 }
                 if (key == 'tag') value = Tag.tagFor[value]
+                else
+                if (value instanceof List) {        // some commands may have collective values
+                    for (Map entryMap in value) {
+                        entryMap.each { entryKey, entryValue ->
+                            entryMap[entryKey] = decodeBaseValue(entryValue)
+                        }
+                    }
+                }
                 else value = decodeBaseValue(value)
                 responseCommand[key] = value
             }
@@ -112,13 +120,13 @@ class JsonCodec implements Codec {
         if (encodedValue instanceof Map && encodedValue.size() == 1) {
             if (encodedValue.containsKey(DATE_TYPE_KEY)) {
                 result = DateFormat.getDateInstance().parse(encodedValue[DATE_TYPE_KEY]);
-            }
+            } else
             if (encodedValue.containsKey(BIGDECIMAL_TYPE_KEY)) {
                 result = new BigDecimal(encodedValue[BIGDECIMAL_TYPE_KEY]);
-            }
+            } else
             if (encodedValue.containsKey(FLOAT_TYPE_KEY)) {
                 result = Float.parseFloat(encodedValue[FLOAT_TYPE_KEY]);
-            }
+            } else
             if (encodedValue.containsKey(DOUBLE_TYPE_KEY)) {
                 result = Double.parseDouble(encodedValue[DOUBLE_TYPE_KEY]);
             }

--- a/subprojects/shared/src/test/groovy/org/opendolphin/core/comm/JsonCodecTest.groovy
+++ b/subprojects/shared/src/test/groovy/org/opendolphin/core/comm/JsonCodecTest.groovy
@@ -142,5 +142,64 @@ public class JsonCodecTest extends GroovyTestCase {
         assert in_command.newValue == out_command.newValue
     }
 
+    /**
+     * this test works until 7fd89dd but not beyond
+     * crashes at [2] with "Attribute values of this type are not allowed: LazyMap"
+     */
+    void testProperTypeEnAndDeAndEnAndDecodingADate() {
 
+        def cpmc = new CreatePresentationModelCommand();
+        cpmc.attributes << [
+                propertyName: "theDate",
+                id          : "0",
+                qualifier   : "1",
+                value       : new Date(),
+                baseValue   : new Date()
+        ]
+        cpmc.pmId = "untilDate0"
+        cpmc.pmType = "aDate"
+
+        def codec = new JsonCodec()
+
+        // [0] from one end
+        def encoded0 = codec.encode([cpmc])
+        // [1] to the other
+        def decoded0 = codec.decode(encoded0)[0];
+        // [2] and back
+        def encoded1 = codec.encode([decoded0])
+        // should work too
+        def decoded1 = codec.decode(encoded1)[0];
+
+        assert decoded1 != null;
+    }
+
+    /**
+     * this test works until 7fd89dd and beyond
+     */
+    void testProperTypeEnAndDeAndEnAndDecodingAString() {
+
+        def cpmc = new CreatePresentationModelCommand();
+        cpmc.attributes << [
+                propertyName: "theMessage",
+                id          : "0",
+                qualifier   : "1",
+                value       : "momo was here",
+                baseValue   : "momo was here"
+        ]
+        cpmc.pmId = "aName"
+        cpmc.pmType = "aString"
+
+        def codec = new JsonCodec()
+
+        // from one end
+        def encoded0 = codec.encode([cpmc])
+        // to the other
+        def decoded0 = codec.decode(encoded0)[0];
+        // and back
+        def encoded1 = codec.encode([decoded0])
+        // should work too
+        def decoded1 = codec.decode(encoded1)[0];
+
+        assert decoded1 != null;
+    }
 }


### PR DESCRIPTION
- the new en/decoding from 7fd89dd actually does not work, encoded base values for collections in commands are no propertly decoded; a second encoding would fail (see: testProperTypeEnAndDeAndEnAndDecodingADate)
- improved decode with if/else chain

I think the JS "port" has the same problem at least for Date; but no fix here yet