### PR TITLE
specify type for ServerConnector and movement to combined

### DIFF
--- a/subprojects/client-javafx/src/test/groovy/org/opendolphin/binding/JFXBinderSpec.groovy
+++ b/subprojects/client-javafx/src/test/groovy/org/opendolphin/binding/JFXBinderSpec.groovy
@@ -16,34 +16,13 @@
 
 package org.opendolphin.binding
 
-import org.opendolphin.core.client.ClientDolphin
-import org.opendolphin.core.client.ClientModelStore
-import org.opendolphin.core.client.ClientPresentationModel
-import org.opendolphin.core.client.comm.InMemoryClientConnector
 import groovy.beans.Bindable
 import spock.lang.Specification
-
-import javax.swing.*
 
 import static org.opendolphin.binding.JFXBinder.bind
 import static org.opendolphin.binding.JFXBinder.unbind
 
 class JFXBinderSpec extends Specification {
-
-    // exposes http://www.canoo.com/jira/browse/DOL-26
-    def 'binding the text property of a Swing component to an Attribute should not throw Exceptions'() {
-        given:
-        def dolphin = new ClientDolphin()
-        dolphin.clientModelStore = new ClientModelStore(dolphin)
-        dolphin.clientConnector = new InMemoryClientConnector(dolphin)
-        ClientPresentationModel loginPM = dolphin.presentationModel("loginPM", [name: "abc"])
-
-        JTextField txtName = new JTextField()
-
-        expect:
-        Binder.bind("name").of(loginPM).to("text").of(txtName)
-        Binder.bind("text").of(txtName).to("name").of(loginPM)
-    }
 
     def 'bind and unbind jfx Node to POJO'() {
         given:

--- a/subprojects/combined/src/main/groovy/org/opendolphin/core/client/comm/InMemoryClientConnector.groovy
+++ b/subprojects/combined/src/main/groovy/org/opendolphin/core/client/comm/InMemoryClientConnector.groovy
@@ -17,22 +17,24 @@
 package org.opendolphin.core.client.comm
 
 import org.opendolphin.core.comm.Command
-import groovy.transform.InheritConstructors
 import groovy.util.logging.Log
 import org.opendolphin.core.client.ClientDolphin
+import org.opendolphin.core.server.ServerConnector
 
-@Log @InheritConstructors
+@Log
 class InMemoryClientConnector extends ClientConnector {
 
     def sleepMillis = 0
-    def serverConnector // must be injected since the class is only available in a "combined" context
+    final ServerConnector serverConnector // must be injected since the class is only available in a "combined" context
 
-    InMemoryClientConnector(ClientDolphin clientDolphin) {
+    InMemoryClientConnector(ClientDolphin clientDolphin, ServerConnector serverConnector) {
         super(clientDolphin)
+        this.serverConnector = serverConnector
     }
 
-    InMemoryClientConnector(ClientDolphin clientDolphin, CommandBatcher commandBatcher) {
+    InMemoryClientConnector(ClientDolphin clientDolphin, ServerConnector serverConnector, CommandBatcher commandBatcher) {
         super(clientDolphin, commandBatcher)
+        this.serverConnector = serverConnector
     }
 
     @Override

--- a/subprojects/combined/src/main/groovy/org/opendolphin/core/client/comm/SynchronousInMemoryClientConnector.groovy
+++ b/subprojects/combined/src/main/groovy/org/opendolphin/core/client/comm/SynchronousInMemoryClientConnector.groovy
@@ -18,7 +18,6 @@ package org.opendolphin.core.client.comm
 
 import groovy.transform.InheritConstructors
 import groovy.util.logging.Log
-import org.opendolphin.core.client.ClientDolphin
 import org.opendolphin.core.comm.Command
 
 /** An in-memory client connector without any asynchronous calls such that
@@ -29,10 +28,6 @@ import org.opendolphin.core.comm.Command
 
 @Log @InheritConstructors
 class SynchronousInMemoryClientConnector extends InMemoryClientConnector {
-
-    SynchronousInMemoryClientConnector(ClientDolphin clientDolphin) {
-        super(clientDolphin)
-    }
 
     protected void startCommandProcessing() {
         /* do nothing! */

--- a/subprojects/combined/src/main/groovy/org/opendolphin/core/comm/DefaultInMemoryConfig.groovy
+++ b/subprojects/combined/src/main/groovy/org/opendolphin/core/comm/DefaultInMemoryConfig.groovy
@@ -32,10 +32,9 @@ class DefaultInMemoryConfig {
         LogConfig.logCommunication()
 
         clientDolphin.clientModelStore = new ClientModelStore(clientDolphin)
-        clientDolphin.clientConnector = new InMemoryClientConnector(clientDolphin)
+        clientDolphin.clientConnector = new InMemoryClientConnector(clientDolphin, serverDolphin.serverConnector)
 
         clientDolphin.clientConnector.sleepMillis = 100
-        clientDolphin.clientConnector.serverConnector = serverDolphin.serverConnector
 
     }
 

--- a/subprojects/combined/src/test/groovy/org/opendolphin/binding/BindingSpec.groovy
+++ b/subprojects/combined/src/test/groovy/org/opendolphin/binding/BindingSpec.groovy
@@ -1,0 +1,30 @@
+package org.opendolphin.binding
+
+
+import org.opendolphin.core.client.ClientDolphin
+import org.opendolphin.core.client.ClientModelStore
+import org.opendolphin.core.client.ClientPresentationModel
+import org.opendolphin.core.client.comm.InMemoryClientConnector
+import org.opendolphin.core.server.ServerConnector
+import spock.lang.Specification
+
+import javax.swing.*
+
+
+class BindingSpec extends Specification {
+
+    // exposes http://www.canoo.com/jira/browse/DOL-26
+    def 'binding the text property of a Swing component to an Attribute should not throw Exceptions'() {
+        given:
+        def dolphin = new ClientDolphin()
+        dolphin.clientModelStore = new ClientModelStore(dolphin)
+        dolphin.clientConnector = new InMemoryClientConnector(dolphin, [:] as ServerConnector)
+        ClientPresentationModel loginPM = dolphin.presentationModel("loginPM", [name: "abc"])
+
+        JTextField txtName = new JTextField()
+
+        expect:
+        Binder.bind("name").of(loginPM).to("text").of(txtName)
+        Binder.bind("text").of(txtName).to("name").of(loginPM)
+    }
+}

--- a/subprojects/combined/src/test/groovy/org/opendolphin/core/client/ClientModelStoreSpec.groovy
+++ b/subprojects/combined/src/test/groovy/org/opendolphin/core/client/ClientModelStoreSpec.groovy
@@ -16,9 +16,10 @@
 
 package org.opendolphin.core.client
 
-import org.opendolphin.core.client.comm.WithPresentationModelHandler
-import spock.lang.Specification
 import org.opendolphin.core.client.comm.InMemoryClientConnector
+import org.opendolphin.core.client.comm.WithPresentationModelHandler
+import org.opendolphin.core.server.ServerConnector
+import spock.lang.Specification
 import org.opendolphin.core.ModelStoreListener
 import org.opendolphin.core.ModelStoreEvent
 
@@ -32,7 +33,7 @@ class ClientModelStoreSpec extends Specification {
         def clientDolphin = new ClientDolphin()
 		modelStore = new ClientModelStore(clientDolphin)
         clientDolphin.clientModelStore = modelStore
-        clientDolphin.clientConnector = new InMemoryClientConnector(clientDolphin)
+        clientDolphin.clientConnector = new InMemoryClientConnector(clientDolphin, [:] as ServerConnector)
 
 		pmType = 'myType'
 		pm = new ClientPresentationModel('myId', [])

--- a/subprojects/combined/src/test/groovy/org/opendolphin/core/client/comm/InMemoryClientConnectorTests.groovy
+++ b/subprojects/combined/src/test/groovy/org/opendolphin/core/client/comm/InMemoryClientConnectorTests.groovy
@@ -2,37 +2,36 @@ package org.opendolphin.core.client.comm
 
 import org.opendolphin.core.client.ClientDolphin
 import org.opendolphin.core.comm.Command
-
-import java.util.concurrent.CountDownLatch
+import org.opendolphin.core.server.ServerConnector
 
 class InMemoryClientConnectorTests extends GroovyTestCase {
 
     void testCallConnector_NoServerConnectorWired() {
-        InMemoryClientConnector connector = new InMemoryClientConnector(new ClientDolphin())
+        InMemoryClientConnector connector = new InMemoryClientConnector(new ClientDolphin(), null)
         assert [] == connector.transmit([new Command()])
     }
 
     void testCallConnector_ServerWired() {
-        InMemoryClientConnector connector = new InMemoryClientConnector(new ClientDolphin())
-        def command = new Command()
         boolean serverCalled = false
-        connector.serverConnector = [receive: { cmd ->
+        def serverConnector = [receive: { cmd ->
             serverCalled = true
             return []
-        }]
+        }] as ServerConnector
+        InMemoryClientConnector connector = new InMemoryClientConnector(new ClientDolphin(), serverConnector)
+        def command = new Command()
         connector.transmit([command])
         assert serverCalled
     }
 
     void testCallConnector_ServerWiredWithSleep() {
-        InMemoryClientConnector connector = new InMemoryClientConnector(new ClientDolphin())
-        connector.sleepMillis = 10
-        def command = new Command()
         boolean serverCalled = false
-        connector.serverConnector = [receive: { cmd ->
+        def serverConnector = [receive: { cmd ->
             serverCalled = true
             return []
-        }]
+        }] as ServerConnector
+        InMemoryClientConnector connector = new InMemoryClientConnector(new ClientDolphin(), serverConnector)
+        connector.sleepMillis = 10
+        def command = new Command()
         connector.transmit([command])
         assert serverCalled
     }

--- a/subprojects/combined/src/test/groovy/org/opendolphin/core/comm/FunctionalPresentationModelTests.groovy
+++ b/subprojects/combined/src/test/groovy/org/opendolphin/core/comm/FunctionalPresentationModelTests.groovy
@@ -113,17 +113,15 @@ class FunctionalPresentationModelTests extends GroovyTestCase {
 
     void testPerformanceWithBlindCommandBatcher() {
         def batcher = new BlindCommandBatcher(mergeValueChanges:true, deferMillis: 100)
-        def connector = new InMemoryClientConnector(context.clientDolphin, batcher)
+        def connector = new InMemoryClientConnector(context.clientDolphin, serverDolphin.serverConnector, batcher)
         connector.uiThreadHandler = new RunLaterUiThreadHandler()
-        connector.serverConnector = serverDolphin.serverConnector
         context.clientDolphin.clientConnector = connector
         doTestPerformance()
     }
 
     void testPerformanceWithSynchronousConnector() {
-        def connector = new SynchronousInMemoryClientConnector(context.clientDolphin)
+        def connector = new SynchronousInMemoryClientConnector(context.clientDolphin, serverDolphin.serverConnector)
         connector.uiThreadHandler = { fail "should not reach here! " } as UiThreadHandler
-        connector.serverConnector = serverDolphin.serverConnector
         context.clientDolphin.clientConnector = connector
         doTestPerformance()
     }


### PR DESCRIPTION
this types the server connector in InMemoryClientConnector as ServerConnector as well as making it a final property one has to give in through the constructor. Due to this change several classes have to move to "combined" as they now reference a server class from the client side. Before this was hidden through the usage of Object. Since this will move files this PR is of course to be seen a bit more critical