### PR TITLE
split type OnFinishedHandler to separate handlers 

### DIFF
--- a/subprojects/client/src/main/groovy/org/opendolphin/core/client/ClientDolphin.groovy
+++ b/subprojects/client/src/main/groovy/org/opendolphin/core/client/ClientDolphin.groovy
@@ -21,6 +21,7 @@ import org.opendolphin.core.ModelStore
 import org.opendolphin.core.PresentationModel
 import org.opendolphin.core.Tag
 import org.opendolphin.core.client.comm.ClientConnector
+import org.opendolphin.core.client.comm.OnFinishedDataAdapter
 import org.opendolphin.core.client.comm.OnFinishedHandler
 import org.opendolphin.core.client.comm.OnFinishedHandlerAdapter
 import org.opendolphin.core.comm.AttributeCreatedNotification
@@ -103,11 +104,7 @@ public class ClientDolphin extends AbstractDolphin<ClientAttribute, ClientPresen
 
     /** groovy-friendly convenience method for sending a named command that expects only data responses*/
     void data(String commandName, Closure onFinished) {
-        clientConnector.send(new NamedCommand(commandName), new OnFinishedHandlerAdapter(){
-            void onFinishedData(List<Map> data) {
-                onFinished(data)
-            }
-        })
+        clientConnector.send(new NamedCommand(commandName), OnFinishedDataAdapter.withAction(onFinished))
     }
 
     /** start of a fluent api: apply source to target. Use for selection changes in master-detail views. */

--- a/subprojects/client/src/main/groovy/org/opendolphin/core/client/comm/ClientConnector.groovy
+++ b/subprojects/client/src/main/groovy/org/opendolphin/core/client/comm/ClientConnector.groovy
@@ -126,9 +126,12 @@ abstract class ClientConnector {
             }
         }
         def callback = commandsAndHandlers.first().handler // there can only be one relevant handler anyway
-        if (callback) {
+        // added != null check instead of using simple Groovy truth because of NPE through GROOVY-7709
+        if (callback !=null) {
             callback.onFinished((List<ClientPresentationModel>) touchedPresentationModels.unique { ((ClientPresentationModel) it).id })
-            callback.onFinishedData(touchedDataMaps)
+            if (callback instanceof OnFinishedData) {
+                callback.onFinishedData(touchedDataMaps)
+            }
         }
     }
 

--- a/subprojects/client/src/main/groovy/org/opendolphin/core/client/comm/OnFinishedData.groovy
+++ b/subprojects/client/src/main/groovy/org/opendolphin/core/client/comm/OnFinishedData.groovy
@@ -1,0 +1,8 @@
+package org.opendolphin.core.client.comm
+
+/**
+ * interface for data point handler
+ */
+interface OnFinishedData extends OnFinishedHandler {
+    void onFinishedData(List<Map> data);
+}

--- a/subprojects/client/src/main/groovy/org/opendolphin/core/client/comm/OnFinishedDataAdapter.groovy
+++ b/subprojects/client/src/main/groovy/org/opendolphin/core/client/comm/OnFinishedDataAdapter.groovy
@@ -1,0 +1,21 @@
+package org.opendolphin.core.client.comm
+
+import org.opendolphin.core.client.ClientPresentationModel
+
+/**
+ * Convenience class for OnFinishedData
+ */
+abstract public class OnFinishedDataAdapter implements OnFinishedData {
+    @Override
+    void onFinished(List<ClientPresentationModel> presentationModels) {
+            // ignore
+    }
+    static OnFinishedData withAction (Closure cl) {
+        return new OnFinishedDataAdapter() {
+            @Override
+            void onFinishedData(List<Map> data) {
+                cl.call(data)
+            }
+        }
+    }
+}

--- a/subprojects/client/src/main/groovy/org/opendolphin/core/client/comm/OnFinishedHandler.java
+++ b/subprojects/client/src/main/groovy/org/opendolphin/core/client/comm/OnFinishedHandler.java
@@ -19,9 +19,10 @@ package org.opendolphin.core.client.comm;
 import org.opendolphin.core.client.ClientPresentationModel;
 
 import java.util.List;
-import java.util.Map;
 
+/**
+ * interface for setting handler executed after command completion
+ */
 public interface OnFinishedHandler {
     public void onFinished(List<ClientPresentationModel> presentationModels);
-    public void onFinishedData(List<Map> data);
 }

--- a/subprojects/client/src/main/groovy/org/opendolphin/core/client/comm/OnFinishedHandlerAdapter.java
+++ b/subprojects/client/src/main/groovy/org/opendolphin/core/client/comm/OnFinishedHandlerAdapter.java
@@ -10,9 +10,4 @@ public class OnFinishedHandlerAdapter implements OnFinishedHandler {
     public void onFinished(List<ClientPresentationModel> presentationModels) {
         // do nothing
     }
-
-    @Override
-    public void onFinishedData(List<Map> data) {
-        // do nothing
-    }
 }

--- a/subprojects/client/src/test/groovy/org/opendolphin/core/client/comm/OnFinishedHandlerAdapterTests.groovy
+++ b/subprojects/client/src/test/groovy/org/opendolphin/core/client/comm/OnFinishedHandlerAdapterTests.groovy
@@ -4,6 +4,14 @@ class OnFinishedHandlerAdapterTests extends GroovyTestCase{
 
     void testAdapter() {
         new OnFinishedHandlerAdapter().onFinished([])
-        new OnFinishedHandlerAdapter().onFinishedData([[:]])
+        def dataAdapter = new OnFinishedDataAdapter(){
+            @Override
+            void onFinishedData(List<Map> data) {
+                // nothing
+            }
+        }
+        dataAdapter.onFinished([])
+        dataAdapter.onFinishedData([])
     }
+
 }

--- a/subprojects/demo-javafx/client/src/main/groovy/org/opendolphin/demo/SmallFootprintView.groovy
+++ b/subprojects/demo-javafx/client/src/main/groovy/org/opendolphin/demo/SmallFootprintView.groovy
@@ -17,21 +17,13 @@
 package org.opendolphin.demo
 
 import javafx.application.Platform
-import javafx.beans.value.ChangeListener
 import javafx.event.EventHandler
 import javafx.scene.paint.Color
 import javafx.scene.shape.Circle
-import jfxtras.labs.scene.control.gauge.Radial
-import jfxtras.labs.scene.control.gauge.StyleModel
 import org.opendolphin.core.client.ClientDolphin
-import org.opendolphin.core.client.comm.OnFinishedHandlerAdapter
-
-import java.beans.PropertyChangeEvent
-import java.beans.PropertyChangeListener
+import org.opendolphin.core.client.comm.OnFinishedDataAdapter
 
 import static groovyx.javafx.GroovyFX.start
-import static jfxtras.labs.scene.control.gauge.Gauge.FrameDesign.CHROME
-import static org.opendolphin.binding.JFXBinder.bind
 import static org.opendolphin.demo.DemoStyle.blueStyle
 /**
 
@@ -99,7 +91,7 @@ class SmallFootprintView {
 
 
             Closure longPoll
-            longPoll = { updateDolphin.send "poll.sfTrigger", new OnFinishedHandlerAdapter(){
+            longPoll = { updateDolphin.send "poll.sfTrigger", new OnFinishedDataAdapter(){
                 @Override
                 void onFinishedData(List<Map> data) {
                     for (map in data) {


### PR DESCRIPTION
...reacting to command completion and handlers reacting to data points. This also changed OnFinishedHandler into a functional interface for later JDK8 lambda expressions usage. OnFinishedData and OnFinishedDataAdapter take the role of handlers reacting to data points. They are realized as optional addon, of course then loosing the functional interface ability