### PR TITLE
Use cookies supplied from server for long poll request

### DIFF
--- a/subprojects/client/src/main/groovy/org/opendolphin/core/client/comm/HttpClientConnector.groovy
+++ b/subprojects/client/src/main/groovy/org/opendolphin/core/client/comm/HttpClientConnector.groovy
@@ -76,6 +76,12 @@ class HttpClientConnector extends ClientConnector {
                 signalHttpClient.execute(httpPost, signalResponseHandler)
             } else {
                 response = httpClient.execute(httpPost, responseHandler)
+
+                def cookieStore = httpClient.cookieStore
+                if( cookieStore ) {
+                    signalHttpClient.cookieStore = cookieStore;
+                }
+
                 log.finest response
                 result = codec.decode(response)
             }


### PR DESCRIPTION
Using OpenDolphin in a scenario with a loadbalancer like haproxy and multiple server instances (jboss/wildfly), its necessary to use cookies from the proxy in both http connections (normal + long polls) - otherwise sticky sessions are difficult to realize.