### PR TITLE
[codec] introduce a date transport encoding based on ISO8601

### DIFF
--- a/subprojects/shared/src/main/groovy/org/opendolphin/core/comm/JsonCodec.groovy
+++ b/subprojects/shared/src/main/groovy/org/opendolphin/core/comm/JsonCodec.groovy
@@ -16,13 +16,13 @@
 
 package org.opendolphin.core.comm
 
-import org.opendolphin.core.BaseAttribute
-import org.opendolphin.core.Tag
 import groovy.json.JsonBuilder
 import groovy.json.JsonSlurper
 import groovy.util.logging.Log
+import org.opendolphin.core.BaseAttribute
+import org.opendolphin.core.Tag
 
-import java.text.DateFormat
+import java.text.SimpleDateFormat
 
 @Log
 class JsonCodec implements Codec {
@@ -32,6 +32,7 @@ class JsonCodec implements Codec {
     public static final String BIGDECIMAL_TYPE_KEY = BigDecimal.toString();
     public static final String FLOAT_TYPE_KEY = Float.toString();
     public static final String DOUBLE_TYPE_KEY = Double.toString();
+    public static final String ISO8601_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
 
     @Override
     String encode(List<Command> commands) {
@@ -65,7 +66,7 @@ class JsonCodec implements Codec {
         def result = BaseAttribute.checkValue(entryValue);
         if (result instanceof Date) {
             def map = [:];
-            map[DATE_TYPE_KEY] = DateFormat.getDateInstance().format(result);
+            map[DATE_TYPE_KEY] = new SimpleDateFormat(ISO8601_FORMAT).format(result)
             result = map
         } else if (result instanceof BigDecimal) {
             def map = [:];
@@ -119,7 +120,7 @@ class JsonCodec implements Codec {
         Object result = encodedValue;
         if (encodedValue instanceof Map && encodedValue.size() == 1) {
             if (encodedValue.containsKey(DATE_TYPE_KEY)) {
-                result = DateFormat.getDateInstance().parse(encodedValue[DATE_TYPE_KEY]);
+                result = new SimpleDateFormat(ISO8601_FORMAT).parse(encodedValue[DATE_TYPE_KEY]);
             } else
             if (encodedValue.containsKey(BIGDECIMAL_TYPE_KEY)) {
                 result = new BigDecimal(encodedValue[BIGDECIMAL_TYPE_KEY]);

--- a/subprojects/shared/src/test/groovy/org/opendolphin/core/comm/JsonCodecTest.groovy
+++ b/subprojects/shared/src/test/groovy/org/opendolphin/core/comm/JsonCodecTest.groovy
@@ -142,7 +142,49 @@ public class JsonCodecTest extends GroovyTestCase {
     }
 
     /**
-     * this test works until 7fd89dd but not beyond
+     * locale might be different for client and server
+     */
+    void testProperTypeEnAndDeAndEnAndDecodingADateDifferentLocale() {
+
+        def cpmc = new CreatePresentationModelCommand();
+        cpmc.attributes << [
+                propertyName: "theDate",
+                id          : "0",
+                qualifier   : "1",
+                value       : new Date(),
+                baseValue   : new Date(),
+        ]
+
+        cpmc.pmId = "untilDate0"
+        cpmc.pmType = "aDate"
+
+        def theOriginalValue = cpmc.attributes.get(0).get("value")
+        def codec = new JsonCodec()
+        def locale = Locale.getDefault()
+
+        try {
+            Locale.setDefault(Locale.GERMAN)
+            def encoded0 = codec.encode([cpmc])
+            Locale.setDefault(Locale.US)
+            def decoded0 = codec.decode(encoded0)[0]
+            // without proper transport encoding, we would end up here with:
+            // java.text.ParseException: Unparseable date: "27.02.2016"
+
+            def encoded1 = codec.encode([decoded0])
+            Locale.setDefault(Locale.GERMAN)
+            def decoded1 = codec.decode(encoded1)[0]
+
+            assert Date.class.cast(decoded1.attributes.get(0).get("value")).compareTo(Date.class.cast(theOriginalValue)) == 0
+
+        } catch (Exception e) {
+            Locale.setDefault(locale)
+            throw e
+        }
+        Locale.setDefault(locale)
+    }
+
+    /**
+     * this test works until 5ca3b2b but not beyond
      * crashes at [2] with "Attribute values of this type are not allowed: LazyMap"
      */
     void testProperTypeEnAndDeAndEnAndDecodingADate() {


### PR DESCRIPTION
baseValue encoding for a date would fail if the locale differs on both ends. introduce a transport encoding based on ISO8601.