### PR TITLE
Fix for concurrent access to release-response

### DIFF
--- a/subprojects/server/src/main/groovy/org/opendolphin/core/server/ServerConnector.groovy
+++ b/subprojects/server/src/main/groovy/org/opendolphin/core/server/ServerConnector.groovy
@@ -15,20 +15,17 @@
  */
 
 package org.opendolphin.core.server
-
+import groovy.util.logging.Log
+import org.codehaus.groovy.runtime.StackTraceUtils
 import org.opendolphin.core.comm.Codec
 import org.opendolphin.core.comm.Command
 import org.opendolphin.core.comm.SignalCommand
-import org.opendolphin.core.server.action.*
-import groovy.transform.CompileStatic
-import groovy.util.logging.Log
-import org.codehaus.groovy.runtime.StackTraceUtils
+import org.opendolphin.core.server.action.DolphinServerAction
+import org.opendolphin.core.server.action.ServerAction
 import org.opendolphin.core.server.comm.ActionRegistry
 import org.opendolphin.core.server.comm.CommandHandler
 
 import java.util.logging.Level
-
-
 //CompileStatic
 @Log
 class ServerConnector {
@@ -48,8 +45,8 @@ class ServerConnector {
             for (DolphinServerAction it in dolphinServerActions) {
                 it.dolphinResponse = response       // todo: can be deleted as soon as all action refer to the SMS
             }
+            serverModelStore.currentResponse = response
         }
-        serverModelStore.currentResponse = response
 
         List<CommandHandler> actions = registry[command.id]
         if (!actions) {


### PR DESCRIPTION
This change fixes a bug that appears when a ReleaseAction takes place at the same time when a PushAction is being answered.

In these cases it is possible that the response list of the ReleaseAction replaces the one that is currently worked on, which means that the commands in the list get lost. Making sure that we do not set serverModelStore.currentResponse when we deal with a SignalCommand fixes the issue.