### PR TITLE
client-java-script: Provide unregistering/disposal of registered event handlers

### DIFF
--- a/subprojects/client-javascript/js/dolphin/ClientModelStore.ts
+++ b/subprojects/client-javascript/js/dolphin/ClientModelStore.ts
@@ -289,11 +289,12 @@ module opendolphin {
             return this.attributesPerQualifier.get(qualifier).slice(0);// slice is used to clone the array
         }
 
-        onModelStoreChange(eventHandler:(event:ModelStoreEvent) => void) {
-            this.modelStoreChangeBus.onEvent(eventHandler);
+        onModelStoreChange(eventHandler:(event:ModelStoreEvent) => void) : Dispose {
+            return this.modelStoreChangeBus.onEvent(eventHandler);
         }
-        onModelStoreChangeForType(presentationModelType:String, eventHandler:(event:ModelStoreEvent) => void) {
-            this.modelStoreChangeBus.onEvent( pmStoreEvent => {
+
+        onModelStoreChangeForType(presentationModelType:String, eventHandler:(event:ModelStoreEvent) => void) : Dispose {
+            return this.modelStoreChangeBus.onEvent( pmStoreEvent => {
                 if (pmStoreEvent.clientPresentationModel.presentationModelType == presentationModelType) {
                     eventHandler(pmStoreEvent);
                 }

--- a/subprojects/client-javascript/js/dolphin/ClientPresentationModel.ts
+++ b/subprojects/client-javascript/js/dolphin/ClientPresentationModel.ts
@@ -105,11 +105,12 @@ module opendolphin {
             });
         }
 
-        onDirty(eventHandler:(event:ValueChangedEvent) => void) {
-            this.dirtyValueChangeBus.onEvent(eventHandler);
+        onDirty(eventHandler:(event:ValueChangedEvent) => void) : Dispose{
+            return this.dirtyValueChangeBus.onEvent(eventHandler);
         }
-        onInvalidated(handleInvalidate:(InvalidationEvent) => void) {
-            this.invalidBus.onEvent(handleInvalidate);
+
+        onInvalidated(handleInvalidate:(InvalidationEvent) => void) : Dispose {
+            return this.invalidBus.onEvent(handleInvalidate);
         }
 
         /** returns a copy of the internal state */

--- a/subprojects/client-javascript/js/dolphin/Dispose.ts
+++ b/subprojects/client-javascript/js/dolphin/Dispose.ts
@@ -1,0 +1,7 @@
+module opendolphin {
+
+  export interface Dispose {
+    () : void;
+  }
+
+}

--- a/subprojects/client-javascript/js/dolphin/EventBus.ts
+++ b/subprojects/client-javascript/js/dolphin/EventBus.ts
@@ -2,12 +2,30 @@ module opendolphin {
 
     export class EventBus<T> {
         private eventHandlers = [];
-        onEvent(eventHandler: (event : T) => void ) {
+
+        /**
+         * Registers eventHandler on this EventBus.
+         * The returned function can be used to unregister the handler later on.
+         *
+         * @param eventHandler
+         * @returns {function(): undefined} to unregister eventHandler
+         */
+        onEvent(eventHandler: (event : T) => void ) : ()=> void {
             this.eventHandlers.push(eventHandler);
+            return () => {
+                this.unregister(eventHandler);
+            }
         }
+
+        unregister(eventHandler) {
+          let idx = this.eventHandlers.indexOf(eventHandler);
+          if (idx > -1) {
+            this.eventHandlers.splice(idx, 1);
+          }
+        };
+
         trigger(event : T ) {
             this.eventHandlers.forEach(handle => handle(event));
         }
-
     }
 }

--- a/subprojects/client-javascript/js/dolphin/EventBus.ts
+++ b/subprojects/client-javascript/js/dolphin/EventBus.ts
@@ -17,6 +17,10 @@ module opendolphin {
             }
         }
 
+        /**
+         * Unregisters eventHanlder from this EventBus.
+         * @param eventHandler
+        */
         unregister(eventHandler) {
           let idx = this.eventHandlers.indexOf(eventHandler);
           if (idx > -1) {

--- a/subprojects/client-javascript/js/dolphin/EventBus.ts
+++ b/subprojects/client-javascript/js/dolphin/EventBus.ts
@@ -18,7 +18,7 @@ module opendolphin {
         }
 
         /**
-         * Unregisters eventHanlder from this EventBus.
+         * Unregisters eventHandler from this EventBus.
          * @param eventHandler
         */
         unregister(eventHandler) {

--- a/subprojects/client-javascript/js/dolphin/tsconfig.json
+++ b/subprojects/client-javascript/js/dolphin/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "out": "./opendolphin.js",
+    "sourceMap": true
+  }
+
+}

--- a/subprojects/client-javascript/test/dolphin/ClientAttributeTests.ts
+++ b/subprojects/client-javascript/test/dolphin/ClientAttributeTests.ts
@@ -12,7 +12,21 @@ module opendolphin {
             this.areNotIdentical(ca1.id, ca2.id);
         }
 
-        valueListenersAreCalled() {
+        valueChangeListenersGetDisposed() {
+            var attr = new ClientAttribute("prop", "qual", 0);
+            var callCount = -1; // Should be zero to begin with, but onValueChange does trigger event on registration!
+
+            var dispose = attr.onValueChange( (evt: ValueChangedEvent) => {
+                ++callCount;
+            } );
+
+            dispose();
+            attr.setValue(1);
+
+            this.areIdentical(0, callCount);
+        }
+
+        valueChangeListenersAreCalled() {
             var attr = new ClientAttribute("prop", "qual", 0);
 
             var spoofedOld = -1;
@@ -32,7 +46,20 @@ module opendolphin {
 
         }
 
-        attributeListenersAreCalled() {
+        qualifierChangeListenersGetDisposed() {
+            var attr = new ClientAttribute("prop", "qual", 0);
+            var called = false;
+            var dispose = attr.onQualifierChange((evt:ValueChangedEvent) => {
+                called = true;
+            })
+
+            dispose();
+            attr.setQualifier("qual_change");
+
+            this.isFalse(called);
+        }
+
+        qualifierChangeListenersAreCalled() {
             var attr = new ClientAttribute("prop", "qual", 0);
 
             var spoofedOldQfr;
@@ -47,7 +74,38 @@ module opendolphin {
             this.areIdentical(spoofedNewQfr, "qual_change")
         }
 
-        valueListenersDoNotInterfere() {
+        baseValueChangeListenersGetDisposed() {
+            var attr = new ClientAttribute("prop", "qual", "base");
+
+            var called = false;
+            var dispose = attr.onBaseValueChange((evt:ValueChangedEvent) => {
+                called = true;
+            })
+            dispose();
+
+            attr.setBaseValue("baseValue change");
+
+            this.isFalse(called);
+        }
+
+        baseValueChangeListenersAreCalled() {
+            var attr = new ClientAttribute("prop", "qual", "base");
+
+            var spoofedOldBaseValue = "";
+            var spoofedNewBaseValue = "";
+
+            attr.onBaseValueChange((evt:ValueChangedEvent) => {
+                spoofedOldBaseValue = evt.oldValue;
+                spoofedNewBaseValue = evt.newValue;
+            })
+
+            attr.setBaseValue("baseValue change");
+
+            this.areIdentical(spoofedOldBaseValue, "base")
+            this.areIdentical(spoofedNewBaseValue, "baseValue change")
+        }
+
+        valueChangeListenersDoNotInterfere() {
             var attr1 = new ClientAttribute("prop", "qual1", 0);
             var attr2 = new ClientAttribute("prop", "qual2", 0);
 
@@ -68,8 +126,21 @@ module opendolphin {
 
         }
 
-        checkDirtyListener() {
+        dirtyChangeListenersGetDisposed() {
             var attr = new ClientAttribute("prop", "qual1", 0);
+
+            var called = false;
+            var dispose = attr.onDirty((evt:ValueChangedEvent) => {
+                called = true;
+            });
+            dispose();
+            attr.setValue(1);
+
+            this.isFalse(called);
+        }
+
+        checkDirtyChangeListener() {
+            var attr = new ClientAttribute("prop", "qual1", false);
 
             var dirtyFirst = false;
             attr.onDirty((evt:ValueChangedEvent) => {
@@ -81,6 +152,7 @@ module opendolphin {
                 dirtySecond = evt.newValue;
             });
 
+            attr.setValue(true);
             this.areIdentical(dirtyFirst, dirtySecond);
         }
 

--- a/subprojects/client-javascript/test/dolphin/ClientModelStoreTests.ts
+++ b/subprojects/client-javascript/test/dolphin/ClientModelStoreTests.ts
@@ -192,7 +192,6 @@ module opendolphin {
             clientModelStore.removeAttributeById(attr1);
             var result1 = clientModelStore.findAttributeById(attr1.id);
             this.areIdentical(result1, undefined);
-
         }
 
         addAndRemoveClientAttributeByQualifier() {
@@ -227,8 +226,6 @@ module opendolphin {
             this.areIdentical(clientAttrs1.length, 1);
             this.areIdentical(clientAttrs1[0].getQualifier(), "qual1");
             this.areIdentical(clientAttrs1[1], undefined);
-
-
         }
 
         checkAttributeBaseValueChangeForSameQualifier(){
@@ -265,8 +262,6 @@ module opendolphin {
             this.areIdentical(clientAttr2.getValue(), "Test");
             this.areIdentical(clientAttr2.getBaseValue(), "Test");
             this.isFalse(clientAttr2.isDirty());
-
-
         }
 
     }

--- a/subprojects/client-javascript/test/dolphin/ClientModelStoreTests.ts
+++ b/subprojects/client-javascript/test/dolphin/ClientModelStoreTests.ts
@@ -131,6 +131,23 @@ module opendolphin {
             this.areIdentical(pm, pm1);
         }
 
+        modelChangeListenersGetDisposed() {
+            var pm1 = new ClientPresentationModel("id1", "type");
+
+            var clientDolphin = new ClientDolphin();
+            var clientModelStore = new ClientModelStore(clientDolphin);
+
+            var called = false;
+            var dispose = clientModelStore.onModelStoreChangeForType("type", (evt:ModelStoreEvent) => {
+                called = true;
+            })
+            dispose();
+
+            clientModelStore.addPresentationModelByType(pm1);
+
+            this.isFalse(called);
+        }
+
         addAndRemovePresentationModelByType() {
             var pm1 = new ClientPresentationModel("id1", "type");
             var pm2 = new ClientPresentationModel("id2", "type");

--- a/subprojects/client-javascript/test/dolphin/ClientPresentationModelTests.ts
+++ b/subprojects/client-javascript/test/dolphin/ClientPresentationModelTests.ts
@@ -31,6 +31,22 @@ module opendolphin {
             this.areIdentical(pm1.getAttributes()[0], firstAttribute);
         }
 
+        invalidatedListenersGetDisposed() {
+            var pm1 = new ClientPresentationModel(undefined,undefined);
+            var clientAttribute = new ClientAttribute("prop", "qual", 0);
+            pm1.addAttribute(clientAttribute);
+
+            var called = false;
+            var dispose = pm1.onInvalidated((event:InvalidationEvent) => {
+                called = true;
+            });
+            dispose();
+
+            clientAttribute.setValue("newValue");
+
+            this.isFalse(called);
+        }
+
         invalidateClientPresentationModelEvent(){
             var pm1 = new ClientPresentationModel(undefined,undefined);
             var clientAttribute = new ClientAttribute("prop", "qual", 0);
@@ -61,6 +77,40 @@ module opendolphin {
 
             //PM should be dirty
             this.areIdentical(pm.isDirty(),true);
+        }
+
+        dirtyListenersGetDisposed() {
+            var pm = new ClientPresentationModel(undefined,undefined);
+            var ca = new ClientAttribute("prop1","qual1","value1","VALUE");
+
+            var called = false;
+            var dispose = pm.onDirty((evt:ValueChangedEvent) => {
+                called = true;
+            });
+            dispose();
+
+            pm.addAttribute(ca);
+
+            this.isFalse(called);
+        }
+
+        dirtyPresentationModelEvent() {
+            var pm = new ClientPresentationModel(undefined,undefined);
+            var ca = new ClientAttribute("prop1","qual1","value1","VALUE");
+            pm.addAttribute(ca);
+
+            var spoofedOldValue = false;
+            var spoofedNewValue = false;
+
+            pm.onDirty((evt:ValueChangedEvent) => {
+                spoofedOldValue = evt.oldValue;
+                spoofedNewValue = evt.newValue;
+            })
+
+            ca.setValue("newValue"); // triggers dirty on pm
+
+            this.isFalse(spoofedOldValue);
+            this.isTrue(spoofedNewValue);
         }
 
         checkPresentationModelIsDirtyAfterRebase(){

--- a/subprojects/client-javascript/test/dolphin/EventbusTests.ts
+++ b/subprojects/client-javascript/test/dolphin/EventbusTests.ts
@@ -1,0 +1,42 @@
+/// <reference path="../../testsuite/tsUnit.ts"/>
+/// <reference path="../../js/dolphin/ClientAttribute.ts"/>
+/// <reference path="../../js/dolphin/ClientPresentationModel.ts"/>
+
+
+module opendolphin {
+
+    interface TestEvent {
+    }
+
+    export class EventBusTests extends tsUnit.TestClass {
+
+        registeredHandlerShouldGetCalled() {
+            var eventBus = new EventBus<TestEvent>();
+
+            var spoofedCalled = false;
+            eventBus.onEvent((evt: TestEvent) => {
+                spoofedCalled = true;
+            } );
+
+            eventBus.trigger({});
+
+            this.isTrue(spoofedCalled);
+        }
+
+        checkUnregisterHandler() {
+            var eventBus = new EventBus<TestEvent>();
+
+            var callCount = 0;
+            var dispose = eventBus.onEvent((evt: TestEvent) => {
+                ++callCount;
+            } );
+
+            eventBus.trigger({});
+            dispose();
+            eventBus.trigger({});
+
+            this.areIdentical(1, callCount);
+        }
+
+    }
+}

--- a/subprojects/client-javascript/testrunner/AllTests.ts
+++ b/subprojects/client-javascript/testrunner/AllTests.ts
@@ -13,6 +13,7 @@
 /// <reference path="../test/dolphin/ClientModelStoreTests.ts"/>
 /// <reference path="../test/dolphin/CodecTest.ts"/>
 /// <reference path="../test/dolphin/DolphinBuilderTest.ts"/>
+///<reference path="../test/dolphin/EventBusTests.ts"/>
 
 module allTests {
     export function testAll() {
@@ -33,6 +34,7 @@ module allTests {
         test.addTestClass(new opendolphin.ClientModelStoreTests(), "ClientModelStoreTests");
         test.addTestClass(new opendolphin.CodecTest(), "CodecTest");
         test.addTestClass(new opendolphin.DolphinBuilderTest(), "DolphinBuilder");
+        test.addTestClass(new opendolphin.EventBusTests(), "EventBus");
 
         return test.run();
     }

--- a/subprojects/client-javascript/testsuite/AllTests.ts
+++ b/subprojects/client-javascript/testsuite/AllTests.ts
@@ -13,6 +13,7 @@
 /// <reference path="../test/dolphin/ClientModelStoreTests.ts"/>
 /// <reference path="../test/dolphin/CodecTest.ts"/>
 /// <reference path="../test/dolphin/DolphinBuilderTest.ts"/>
+///<reference path="../test/dolphin/EventBusTests.ts"/>
 
 
 // new instance of tsUnit
@@ -39,6 +40,7 @@ module allTests {
         test.addTestClass(new opendolphin.ClientModelStoreTests(), "ClientModelStoreTests");
         test.addTestClass(new opendolphin.CodecTest(), "CodecTest");
         test.addTestClass(new opendolphin.DolphinBuilderTest(), "DolphinBuilder");
+        test.addTestClass(new opendolphin.EventBusTests(), "EventBus");
 
         var result = test.run();
 


### PR DESCRIPTION
## Motivation 
Currently, there is no way to unregister change listeners on ClientAttribute, ClientPresentationModel, and ClientModelStore. This leads to loitering listeners, when the OD objects outlive the listeners.

There should be an easy and straight-forward way to unregister listeners.

## Implemented solution
EventBus.onEvent() returns a dispose-function that can be called to un-register the eventHandler, see EventBusTests.ts.

All onXXX-event-registration methods on ClientAttribute, ClientPresentationModel, and ClientModelStore now return the dispose function from the respective backing EventBus instance.

**Note:** On the Java side there are register and unregister methods to add and remove listeners. Since the JS side already differs from the Java implementation, I took the liberty to go for the more functional approach returning a dispose function instead. This pattern is easy to use and allows you to e.g. store all dispose functions in an array and then loop over this array to call the dispose functions when the time comes. E.g. with Angular you can use $onDestroy in the component life-cycle hooks to dispose of all the registered listeners.

_We could add explicit unregister methods on ClientAttribute, ClientPresentationModel, and ClientModelStore, if there is the need to make the JS client more Java-like. But honestly, I would prefer it the other way round ;-)_